### PR TITLE
Add responsive scaling

### DIFF
--- a/client/main.js
+++ b/client/main.js
@@ -71,7 +71,7 @@ async function view() {
 
   /* DOM skeleton */
   const app = document.querySelector("#app");
-  app.innerHTML = `<div style="text-align:center;margin-top:12px"><img src="${logo}" style="max-width:90%"></div>`;
+  app.innerHTML = `<div style="text-align:center;margin-top:12px"><img src="${logo}" class="logo"></div>`;
 
   const wrap = document.createElement("div");
   wrap.style.cssText = "margin-top:12px;position:relative;display:inline-block;";
@@ -98,6 +98,23 @@ async function view() {
   can.height = TOP  + ROWS * CELL + 4;
   wrap.appendChild(can);
   const ctx = can.getContext("2d");
+  let rect;
+
+  /* responsive scaling */
+  let scale = 1;
+  const fitScale = () => {
+    const boardW = can.width;
+    const boardH = can.height;
+    const margin = 20;
+    const scaleX = (window.innerWidth - margin) / boardW;
+    const scaleY = (window.innerHeight - margin) / (boardH + 200);
+    scale = Math.min(scaleX, scaleY, 1);
+    wrap.style.transformOrigin = "top left";
+    wrap.style.transform = `scale(${scale})`;
+    rect = null;
+  };
+  window.addEventListener("resize", fitScale);
+  fitScale();
 
   /* TIMER */
   let tStart = 0, tHandle = 0, ticking = false;
@@ -205,11 +222,12 @@ async function view() {
 
   can.addEventListener("contextmenu", e => e.preventDefault());
 
-  let rect;
   const updateHover = e => {
     rect = rect || can.getBoundingClientRect();
-    const x = Math.floor((e.clientX - rect.left - LEFT) / CELL);
-    const y = Math.floor((e.clientY - rect.top  - TOP)  / CELL);
+    const scaledX = (e.clientX - rect.left) / scale;
+    const scaledY = (e.clientY - rect.top)  / scale;
+    const x = Math.floor((scaledX - LEFT) / CELL);
+    const y = Math.floor((scaledY - TOP)  / CELL);
     if (x >= 0 && y >= 0 && x < COLS && y < ROWS) { hoverX = x; hoverY = y; }
     else { hoverX = hoverY = -1; }
   };

--- a/client/style.css
+++ b/client/style.css
@@ -61,8 +61,8 @@ h1 {
 
 
 .logo {
-  height: 200px;
-  max-width: 100%;
+  max-width: 90vw;
+  height: auto;
   margin-bottom: 1.5rem;
   object-fit: contain;
   will-change: filter;
@@ -73,6 +73,12 @@ h1 {
 }
 .logo.vanilla:hover {
   filter: drop-shadow(0 0 2em #f7df1eaa);
+}
+
+@media (min-width: 768px) {
+  .logo {
+    max-width: 600px;
+  }
 }
 
 button {
@@ -105,4 +111,10 @@ button:focus-visible {
   button {
     background-color: #f9f9f9;
   }
+}
+
+canvas {
+  display: block;
+  max-width: 100%;
+  height: auto;
 }


### PR DESCRIPTION
## Summary
- scale logo to viewport width and limit size on large screens
- resize puzzle wrapper based on window size
- fix pointer calculations after scaling

## Testing
- `npm run build --prefix client`

------
https://chatgpt.com/codex/tasks/task_e_6859a5503878832484fce9c3241d8a22