### PR TITLE
Fix responsive layout for canvas and logo

### DIFF
--- a/client/main.js
+++ b/client/main.js
@@ -50,19 +50,7 @@ const MAX_COL = Math.max(...colClues.map(a => a.length));
 
 const CLUE_RATIO = 22 / 69;
 const MIN_CELL = 30;
-const CELL = Math.max(
-  MIN_CELL,
-  Math.floor(
-    Math.min(
-      (window.innerWidth - 16) / (COLS + MAX_ROW * CLUE_RATIO),
-      (window.innerHeight - 16) / (ROWS + MAX_COL * CLUE_RATIO)
-    )
-  )
-);
-const CLUE = Math.round(CELL * CLUE_RATIO);
-
-const LEFT = MAX_ROW * CLUE + 12;   // board origin X
-const TOP  = MAX_COL * CLUE + 12;   // board origin Y
+let CELL, CLUE, LEFT, TOP;
 
 /* ───────── MAIN ───────── */
 async function view() {
@@ -83,11 +71,29 @@ async function view() {
 
   /* DOM skeleton */
   const app = document.querySelector("#app");
-  app.innerHTML = `<div style="text-align:center;margin-top:12px"><img src="${logo}" style="max-width:90%"></div>`;
+  app.innerHTML = `<div style="text-align:center;margin-top:12px"><img src="${logo}" class="logo"></div>`;
 
   const wrap = document.createElement("div");
   wrap.style.cssText = "margin-top:12px;position:relative;display:inline-block;";
   app.appendChild(wrap);
+
+  const logoImg = app.querySelector(".logo");
+  await logoImg.decode();
+
+  const availableHeight = window.innerHeight - app.offsetHeight - 16;
+  const availableWidth  = window.innerWidth - 16;
+  CELL = Math.max(
+    MIN_CELL,
+    Math.floor(
+      Math.min(
+        availableWidth  / (COLS + MAX_ROW * CLUE_RATIO),
+        availableHeight / (ROWS + MAX_COL * CLUE_RATIO)
+      )
+    )
+  );
+  CLUE = Math.round(CELL * CLUE_RATIO);
+  LEFT = MAX_ROW * CLUE + 12;
+  TOP  = MAX_COL * CLUE + 12;
 
   /* HUD */
   const hud = document.createElement("div");

--- a/client/style.css
+++ b/client/style.css
@@ -62,8 +62,9 @@ h1 {
 
 
 .logo {
-  height: 200px;
-  max-width: 100%;
+  width: 90%;
+  height: auto;
+  max-width: 600px;
   margin-bottom: 1.5rem;
   object-fit: contain;
   will-change: filter;


### PR DESCRIPTION
## Summary
- allow the title logo to scale with the viewport
- compute board size after logo loads so canvas fits available space

## Testing
- `npm run build --silent`

------
https://chatgpt.com/codex/tasks/task_e_6859b590f1a483248755a7c8a640840d